### PR TITLE
Add a method to temporarily disable easyescape

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ let g:easyescape_timeout = 100
 cnoremap jj <ESC>
 ```
 
+### Disable easyescape based on filetype
+
+```
+autocmd FileType text,markdown call setbufvar(bufnr("%"), 'easyescape_disable', 1)
+```
+
 ## Dependency
 
 Python3 is required if timeout (`g:easyescape_timeout`) is less than 2000 ms because vim does not provide a way to fetch sub-second time.

--- a/plugin/easyescape.vim
+++ b/plugin/easyescape.vim
@@ -47,6 +47,9 @@ function! s:EasyescapeReadTimer()
 endfunction
 
 function! <SID>EasyescapeMap(char)
+    if exists("b:easyescape_disable") && b:easyescape_disable == 1
+        return a:char
+    endif
     if s:current_chars[a:char] == 0
         let s:current_chars = copy(g:easyescape_chars)
         let s:current_chars[a:char] = s:current_chars[a:char] - 1
@@ -93,3 +96,5 @@ else
 endif
 
 let s:escape_sequence = repeat("\<BS>", eval(join(values(g:easyescape_chars), "+"))-1) . "\<ESC>"
+
+" vim:set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
I've added a method to disable easyescape. This is useful when you want to have easyescape on for certain filetypes and off for others. Or you can disable it when having spell language set to Dutch.
That last one is useful to me, because I like having easyescape bound to 'jk', but that doesn't work well when typing in Dutch. Changing the mapping doesn't work, because mappings have to be regenerated, so I found this to be an easy option.